### PR TITLE
Fix bug with tabs not displaying in IE

### DIFF
--- a/src/components/_tab.scss
+++ b/src/components/_tab.scss
@@ -68,7 +68,7 @@
   display: none;
 
   &.ias-open {
-    display: initial;
+    display: block;
   }
 }
 


### PR DESCRIPTION
IE doesn't recognize `display: initial`.